### PR TITLE
Adding new digit validation method

### DIFF
--- a/app/scripts/angular-boleto.js
+++ b/app/scripts/angular-boleto.js
@@ -96,14 +96,6 @@ angular.module('angular.boleto', ['ui.mask'])
             return false;
           }
 
-          // TODO: Para poder calcular o dígito verificador será necessário identificar o banco pois há diferenças na verificação para alguns bancos como o BB por exemplo.
-          /*
-          if (numeroBoleto.length === 47 && calcularDigitoVerificadorGeral(numeroBoleto.substr(0, 4) + numeroBoleto.substr(5, 39)) != numeroBoleto.substr(4, 1)) {
-            scope.form[scope.name].$setValidity('verificadorErrado', false);
-            return false;
-          }
-          */
-
           if (numeroBoleto.length === 47 && validarBlocos(numeroBoleto)) {
             return true;
           }
@@ -120,7 +112,6 @@ angular.module('angular.boleto', ['ui.mask'])
           scope.form[scope.name].$setValidity('vencimentoErrado', true);
         }; // resetarValidade
 
-        /*
         var calcularDigitoVerificadorGeral = function (numero) {
           var soma  = 0;
           var peso  = 2;
@@ -141,7 +132,6 @@ angular.module('angular.boleto', ['ui.mask'])
             digito = 1;
           return digito;
         }; // calcularDigitoVerificadorGeral
-        */
 
         var calcularDigitoVerificador = function (numero) {
           var soma  = 0;
@@ -218,7 +208,12 @@ angular.module('angular.boleto', ['ui.mask'])
             return false;
           }
 
-          //var campo4 = numeroBoleto.substr(32, 1); // Digito verificador
+          var codBarras = numeroBoleto.substr(0, 4) + numeroBoleto.substr(32, 15) +
+            numeroBoleto.substr(4, 5) + numeroBoleto.substr(10, 10) + numeroBoleto.substr(21, 10);
+          if (calcularDigitoVerificadorGeral(codBarras.substr(0, 4) + codBarras.substr(5, 39)) != codBarras.substr(4, 1)) {
+            scope.form[scope.name].$setValidity('verificadorErrado', false);
+            return false;
+          }
 
           if (typeof scope.validarVencimento !== 'undefined' && scope.validarVencimento !== '') {
             var fatorVencimento = numeroBoleto.substr(33, 4);

--- a/test/boletoSpec.js
+++ b/test/boletoSpec.js
@@ -26,7 +26,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto válido', function () {
     $rootScope.valor = 0.00;
-    $scope.form1.boleto.$setViewValue('10491504263100090855355227287939364140000000000');
+    $scope.form1.boleto.$setViewValue('10491504263100090855355227287939664140000000000');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -35,7 +35,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto válido', function () {
     $rootScope.valor = 934.23;
-    $scope.form1.boleto.$setViewValue('10491443385511900000200000000141325230000093423');
+    $scope.form1.boleto.$setViewValue('10491443385511900000200000000141125230000093423');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -44,7 +44,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto válido', function () {
     $rootScope.valor = 0.00;
-    $scope.form1.boleto.$setViewValue('10491443385511900000200000000141325230000000000');
+    $scope.form1.boleto.$setViewValue('10491443385511900000200000000141725230000000000');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -53,7 +53,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar inválido com código de boleto com valor errado', function () {
     $rootScope.valor = 1274567.89;
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180100000987654321');
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180200000987654321');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(false);
@@ -63,7 +63,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com valor correto', function () {
     $rootScope.valor = 1274567.89;
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180100000127456789');
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180700000127456789');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -116,6 +116,15 @@ describe('Campo de boleto bancário', function () {
     expect($scope.form1.boleto.$error.bloco3Errado).toBe(true);
   });
 
+  it ('deverá estar inválido com código de boleto com verificador inválido', function () {
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180200000000000000');
+    $scope.$digest();
+
+    expect($scope.form1.$valid).toBe(false);
+    expect($scope.form1.boleto.$valid).toBe(false);
+    expect($scope.form1.boleto.$error.verificadorErrado).toBe(true);
+  });
+
   it ('deverá estar válido com código de boleto com vencimento correto', function () {
     $rootScope.vencimento = '2014-01-18';
     $scope.form1.boleto.$setViewValue('21890010070014560208200371313180159470127456789'); // 18/01/2014
@@ -128,7 +137,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com vencimento correto', function () {
     $rootScope.vencimento = '2015-10-03';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180165700127456789'); // 03/10/2015
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180365700127456789'); // 03/10/2015
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -167,7 +176,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar inválido com código de boleto com vencimento menor a data de vencimento da ordem de pagamento', function () {
     $rootScope.vencimento = '01/01/2017';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180570250127456789'); // 31/12/2016
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180270250127456789'); // 31/12/2016
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(false);
@@ -177,7 +186,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com vencimento correto', function () {
     $rootScope.vencimento = '2014-03-12';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180160000127456789'); // 12/03/2014
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180360000127456789'); // 12/03/2014
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -187,7 +196,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com fator de vencimento zerado', function () {
     $rootScope.vencimento = '2014-03-12';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180100000127456789');
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180700000127456789');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -198,7 +207,7 @@ describe('Campo de boleto bancário', function () {
   /*** Testes para comunicado FEBRABAN de n° 082/2012 de 14/06/2012 ***/
   it ('deverá estar válido com código de boleto com vencimento correto', function () {
     $rootScope.vencimento = '2025-02-21';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180199990127456789'); // 21/02/2025
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180499990127456789'); // 21/02/2025
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -218,7 +227,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com vencimento correto', function () {
     $rootScope.vencimento = '2025-02-23';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180110010127456789'); // 04/07/2000
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180510010127456789'); // 04/07/2000
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -249,7 +258,7 @@ describe('Campo de boleto bancário', function () {
 
   it ('deverá estar válido com código de boleto com valor correto', function () {
     $rootScope.valor = '1274567.89';
-    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180100000127456789');
+    $scope.form1.boleto.$setViewValue('21890010070014560208200371313180700000127456789');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(true);
@@ -358,7 +367,7 @@ describe('Campo de boleto bancário', function () {
   it ('deverá estar inválido com código de boleto com vencimento incorreto', function () {
     $rootScope.vencimento = '2015-10-05';
 
-    $scope.form1.boleto.$setViewValue('34191576687788152637800168490001656720000477000');
+    $scope.form1.boleto.$setViewValue('34191576687788152637800168490001756720000477000');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(false);
@@ -369,7 +378,7 @@ describe('Campo de boleto bancário', function () {
   it ('deverá estar inválido com código de boleto com vencimento incorreto', function () {
     $rootScope.vencimento = '2015-10-16';
 
-    $scope.form1.boleto.$setViewValue('23792394099000001381480001149402658300000138180');
+    $scope.form1.boleto.$setViewValue('23792394099000001381480001149402358300000138180');
     $scope.$digest();
 
     expect($scope.form1.$valid).toBe(false);


### PR DESCRIPTION
# Tarefa / *user history*

[SP-1311](https://hurbcom.atlassian.net/jira/software/c/projects/SP/boards/12?modal=detail&selectedIssue=SP-1311)

Hoje o sistema de fornecedores/recebíveis possui uma validação de alguns dados do boleto digitável pelo parceiro. Porém existem casos onde o parceiro digita um outro dígito errado e isso só é detectado após o SAP solicitar o pagamento da fatura.

Precisamos complementar a validação existente para identificar os erros o quanto antes.

# O quê esse PR faz?

Adiciona um novo método para validar o dígito verificador geral nos números de boleto.

## - Antes

O dígito verificador geral não estava sendo validado.

## - Depois

O dígito verificador geral passa a ser validado e, caso este esteja errado, é retornado uma mensagem de erro.

## - Como testar?

Acessar a área do fornecedor usando um fornecedor com a opção de pagamento como faturado e requisitar a geração de uma nova fatura usando vouchers em aberto. Preencher o campo de "número boleto" com informações válidas e inválidas e verificar se algum erro é retornado e qual a mensagem associada.

## - TODOs
- [ ] Testes
- [ ] Documentação
- [ ] Débito técnico

# Criou o RC a partir da master?
- [X] Sim
- [ ] Não

# Precisa de migration?
- [ ] Sim
- [X] Não

# Risks
Nenhum risco mapeado

# PS: Não se esqueça de enviar a PR para master após o código estar estável em produção!!
